### PR TITLE
redefine partner and portal AAD "domain" as Tenant ID

### DIFF
--- a/Source/CustomerPortal.Deployment/Templates/WebSite.json
+++ b/Source/CustomerPortal.Deployment/Templates/WebSite.json
@@ -14,7 +14,7 @@
             "type": "string",
             "minLength": 1
         },
-        "webPortalDomain": {
+        "webPortalAadTenantId": {
             "type": "string",
             "minLength": 1
         },
@@ -26,7 +26,7 @@
             "type": "string",
             "minLength": 1
         },
-        "partnerCenterApplicationDomain": {
+        "partnerCenterAadTenantId": {
             "type": "string",
             "minLength": 1
         },
@@ -181,13 +181,13 @@
                     "properties": {
                         "webPortal.clientId": "[parameters('webPortalClientId')]",
                         "webPortal.clientSecret": "[parameters('webPortalClientSecret')]",
-                        "webPortal.domain": "[parameters('webPortalDomain')]",
+                        "webPortal.AadTenantId": "[parameters('webPortalAadTenantId')]",
                         "aadEndpoint": "[parameters('aadAuthorityEndpoint')]",
                         "aadGraphEndpoint": "[parameters('graphEndpoint')]",
                         "partnerCenter.apiEndPoint": "[parameters('partnercenterApiEndpoint')]",
                         "partnerCenter.applicationId": "[parameters('partnerCenterApplicationId')]",
                         "partnerCenter.applicationSecret": "[parameters('partnerCenterApplicationSecret')]",
-                        "partnerCenter.domain": "[parameters('partnerCenterApplicationDomain')]",
+                        "partnerCenter.AadTenantId": "[parameters('partnerCenterAadTenantId')]",
                         "webPortal.azureStorageConnectionString": "[Concat('DefaultEndpointsProtocol=https;AccountName=',variables('CustomerPortalStorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('CustomerPortalStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value)]",
                         "webPortal.azureStorageConnectionEndpointSuffix": "[parameters('azureStorageConnectionEndpointSuffix')]",
                         "webPortal.cacheConnectionString":  ""

--- a/Source/CustomerPortal.Deployment/Templates/WebSite.parameters.json
+++ b/Source/CustomerPortal.Deployment/Templates/WebSite.parameters.json
@@ -20,7 +20,7 @@
         "partnerCenterApplicationSecret": {
             "value": ""
         },
-        "partnerCenterApplicationDomain": {
+        "partnerCenterAadTenantId": {
             "value": ""
         },
         "webPortalClientId": {

--- a/Source/PartnerCenter.CustomerPortal/App_Start/Startup.Auth.cs
+++ b/Source/PartnerCenter.CustomerPortal/App_Start/Startup.Auth.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Store.PartnerCenter.CustomerPortal
                                 }
                             }
 
-                            if (userTenantId != ApplicationConfiguration.ActiveDirectoryDomain)
+                            if (userTenantId != ApplicationConfiguration.ActiveDirectoryTenantId)
                             {
                                 string partnerCenterCustomerId = string.Empty;
 

--- a/Source/PartnerCenter.CustomerPortal/BusinessLogic/ApplicationDomain.cs
+++ b/Source/PartnerCenter.CustomerPortal/BusinessLogic/ApplicationDomain.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Store.PartnerCenter.CustomerPortal.BusinessLogic
             var credentials = await PartnerCredentials.Instance.GenerateByApplicationCredentialsAsync(
                 ConfigurationManager.AppSettings["partnercenter.applicationId"],
                 ConfigurationManager.AppSettings["partnercenter.applicationSecret"],
-                ConfigurationManager.AppSettings["partnercenter.domain"],
+                ConfigurationManager.AppSettings["partnercenter.AadTenantId"],
                 ConfigurationManager.AppSettings["aadEndpoint"],
                 ConfigurationManager.AppSettings["aadGraphEndpoint"]);
 

--- a/Source/PartnerCenter.CustomerPortal/BusinessLogic/CustomerPortalPrincipal.cs
+++ b/Source/PartnerCenter.CustomerPortal/BusinessLogic/CustomerPortalPrincipal.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Store.PartnerCenter.CustomerPortal.BusinessLogic
             get
             {
                 // TODO: later on, we may want to implement RBAC but as of now, all users signed in from the portal's tenant are considered admins
-                return this.TenantId == ApplicationConfiguration.ActiveDirectoryDomain;
+                return this.TenantId == ApplicationConfiguration.ActiveDirectoryTenantId;
             }
         }
 

--- a/Source/PartnerCenter.CustomerPortal/Configuration/ApplicationConfiguration.cs
+++ b/Source/PartnerCenter.CustomerPortal/Configuration/ApplicationConfiguration.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Store.PartnerCenter.CustomerPortal.Configuration
         private const string WebPortalADClientSecretKey = "webPortal.clientSecret";
 
         /// <summary>
-        /// The web portal AD client secret configuration key.
+        /// The web portal AD tenant ID.
         /// </summary>
-        private const string WebPortalADDomainKey = "webPortal.domain"; 
+        private const string WebPortalAadTenantID = "webPortal.AadTenantId";
 
         /// <summary>
         /// The web portal configuration file path configuration key.
@@ -160,13 +160,13 @@ namespace Microsoft.Store.PartnerCenter.CustomerPortal.Configuration
         }
 
         /// <summary>
-        /// Gets the Azure Active Directory domain of the web portal.
+        /// Gets the Azure Active Directory ID of the web portal.
         /// </summary>
-        public static string ActiveDirectoryDomain
+        public static string ActiveDirectoryTenantId
         {
             get
             {
-                return ConfigurationManager.AppSettings[ApplicationConfiguration.WebPortalADDomainKey];
+                return ConfigurationManager.AppSettings[ApplicationConfiguration.WebPortalAadTenantID];
             }
         }
 

--- a/Source/PartnerCenter.CustomerPortal/Web.config
+++ b/Source/PartnerCenter.CustomerPortal/Web.config
@@ -26,8 +26,8 @@
     <!-- Enter your partner center onboarded AAD application secret here -->
     <add key="partnerCenter.applicationSecret" value="" />
     
-    <!-- Enter your partner center AAD domain here -->
-    <add key="partnerCenter.domain" value="" />
+    <!-- Enter your partner center AAD tenant ID here -->
+    <add key="partnerCenter.AadTenantId" value="" />
 
     <!-- The partner center API endpoint -->
     <add key="partnerCenter.apiEndPoint" value="https://api.partnercenter.microsoft.com" />
@@ -38,8 +38,8 @@
     <!-- The AAD client secret of the application running the web portal -->
     <add key="webPortal.clientSecret" value="" />
 
-    <!-- The AAD domain of the application running the web portal -->
-    <add key="webPortal.domain" value="" />
+    <!-- The AAD tenant ID of the application running the web portal -->
+    <add key="webPortal.AadTenantId" value="" />
 
     <!-- The path of the web portal configuration file -->
     <add key="webPortal.configurationPath" value="Configuration\WebPortalConfiguration.json" />

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -14,7 +14,7 @@
       "type": "string",
       "minLength": 1
     },
-    "webPortalDomain": {
+    "webPortalAadTenantId": {
       "type": "string",
       "minLength": 1
     },
@@ -26,7 +26,7 @@
       "type": "string",
       "minLength": 1
     },
-    "partnerCenterApplicationDomain": {
+    "partnerCenterAadTenantId": {
       "type": "string",
       "minLength": 1
     },
@@ -167,11 +167,11 @@
               "aadGraphEndpoint": "[parameters('graphEndpoint')]",
               "webPortal.clientId": "[parameters('webPortalClientId')]",
               "webPortal.clientSecret": "[parameters('webPortalClientSecret')]",
-              "webPortal.domain": "[parameters('webPortalDomain')]",
+              "webPortal.AadTenantId": "[parameters('webPortalAadTenantId')]",
               "partnerCenter.apiEndPoint": "[parameters('partnercenterApiEndpoint')]",
               "partnerCenter.applicationId": "[parameters('partnerCenterApplicationId')]",
               "partnerCenter.applicationSecret": "[parameters('partnerCenterApplicationSecret')]",
-              "partnerCenter.domain": "[parameters('partnerCenterApplicationDomain')]",
+              "partnerCenter.AadTenantId": "[parameters('partnerCenterAadTenantId')]",
               "webPortal.azureStorageConnectionString": "[Concat('DefaultEndpointsProtocol=https;AccountName=',variables('CustomerPortalStorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('CustomerPortalStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value)]",
               "webPortal.azureStorageConnectionEndpointSuffix": "[parameters('azureStorageConnectionEndpointSuffix')]",
               "webPortal.cacheConnectionString": ""

--- a/azuredeploy.param.json
+++ b/azuredeploy.param.json
@@ -11,7 +11,7 @@
   "partnerCenterApplicationSecret": {
     "value": ""
   },
-  "partnerCenterApplicationDomain": {
+  "partnerCenterAadTenantId": {
     "value": ""
   },
   "webPortalClientId": {


### PR DESCRIPTION
Fixes issue #2 by redefining 'domain' as 'ID'