### PR TITLE
override default timeout for paypal due to performance of sandbox

### DIFF
--- a/Source/PartnerCenter.CustomerPortal/BusinessLogic/Commerce/PaymentGateways/PayPalGateway.cs
+++ b/Source/PartnerCenter.CustomerPortal/BusinessLogic/Commerce/PaymentGateways/PayPalGateway.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Store.PartnerCenter.CustomerPortal.BusinessLogic.Commerce.Pa
                 configMap.Add("clientId", paymentConfig.ClientId);
                 configMap.Add("clientSecret", paymentConfig.ClientSecret);
                 configMap.Add("mode", paymentConfig.AccountType);
+                configMap.Add("connectionTimeout", "120000");
 
                 string accessToken = new OAuthTokenCredential(configMap).GetAccessToken();
                 var apiContext = new APIContext(accessToken);
@@ -270,6 +271,7 @@ namespace Microsoft.Store.PartnerCenter.CustomerPortal.BusinessLogic.Commerce.Pa
             configMap.Add("clientId", paymentConfig.ClientId);
             configMap.Add("clientSecret", paymentConfig.ClientSecret);
             configMap.Add("mode", paymentConfig.AccountType);
+            configMap.Add("connectionTimeout", "120000");
 
             string accessToken = new OAuthTokenCredential(configMap).GetAccessToken();
             var apiContext = new APIContext(accessToken);


### PR DESCRIPTION
Fixes issue #3 by adding a hardcoded timeout of 120 seconds.

Since the payment provider configuration is not held in the application deployment config , and this doesn't make sense to expose to the user, I chose to hard code it for now. 