### PR TITLE
Update PayPalGateway.cs

### DIFF
--- a/Source/PartnerCenter.CustomerPortal/BusinessLogic/Commerce/PaymentGateways/PayPalGateway.cs
+++ b/Source/PartnerCenter.CustomerPortal/BusinessLogic/Commerce/PaymentGateways/PayPalGateway.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Store.PartnerCenter.CustomerPortal.BusinessLogic.Commerce.Pa
                     presentation = new Presentation
                     {
                         brand_name = brandConfig.OrganizationName,                        
-                        logo_image = brandConfig.HeaderImage.ToString(),
+                        logo_image = brandConfig.HeaderImage?.ToString(),
                         locale_code = countryIso2Code
                     },
                     input_fields = new InputFields()


### PR DESCRIPTION
Fixing the null reference error which may occur during payment configuration setup if no Header image is setup in the branding configuration for the storefront.