### PR TITLE
Adding support for monthly billing and offer display index

### DIFF
--- a/src/Storefront/BusinessLogic/Commerce/CommerceOperations.cs
+++ b/src/Storefront/BusinessLogic/Commerce/CommerceOperations.cs
@@ -49,16 +49,33 @@ namespace Microsoft.Store.PartnerCenter.Storefront.BusinessLogic.Commerce
         /// Calculates the amount to charge for buying an extra additional seat for the remainder of a subscription's lease.
         /// </summary>
         /// <param name="expiryDate">The subscription's expiry date.</param>
-        /// <param name="yearlyRatePerSeat">The subscription's yearly price per seat.</param>
+        /// <param name="ratePerSeat">The subscription's price per seat, either yearly or mothly depending on the billing cycle.</param>
+        /// <param name="billingCycle">The billing cycle.</param>
         /// <returns>The prorated amount to charge for the new extra seat.</returns>
-        public static decimal CalculateProratedSeatCharge(DateTime expiryDate, decimal yearlyRatePerSeat)
+        public static decimal CalculateProratedSeatCharge(DateTime expiryDate, decimal ratePerSeat, BillingCycleType billingCycle)
         {
             DateTime rightNow = DateTime.UtcNow;
             expiryDate = expiryDate.ToUniversalTime();
 
+            // Determine the total yearly price per seat
+            decimal yearlyRatePerSeat;
+
+            switch (billingCycle)
+            {
+                case BillingCycleType.Annual:
+                    yearlyRatePerSeat = ratePerSeat;
+                    break;
+                case BillingCycleType.Monthly:
+                    yearlyRatePerSeat = ratePerSeat * 12m;
+                    break;
+                default:
+                    throw new NotImplementedException($"Billing cycle {billingCycle} is not implemented");
+            }
+
+            // Calculate the daily price per seat
             decimal dailyChargePerSeat = yearlyRatePerSeat / 365m;
 
-            // round up the remaining days in case there was a fraction and ensure it does not exceed 365 days
+            // Round up the remaining days in case there was a fraction and ensure it does not exceed 365 days
             decimal remainingDaysTillExpiry = Math.Ceiling(Convert.ToDecimal((expiryDate - rightNow).TotalDays));
             remainingDaysTillExpiry = Math.Min(remainingDaysTillExpiry, 365);
 
@@ -94,8 +111,10 @@ namespace Microsoft.Store.PartnerCenter.Storefront.BusinessLogic.Commerce
             AuthorizePayment paymentAuthorization = new AuthorizePayment(PaymentGateway);
             subTransactions.Add(paymentAuthorization);
 
+            BrandingConfiguration portalBranding = await ApplicationDomain.Instance.PortalBranding.RetrieveAsync().ConfigureAwait(false);
+
             // build the Partner Center order and pass it to the place order transaction
-            Order partnerCenterPurchaseOrder = BuildPartnerCenterOrder(lineItemsWithOffers);
+            Order partnerCenterPurchaseOrder = BuildPartnerCenterOrder(lineItemsWithOffers, portalBranding.BillingCycle);
 
             PlaceOrder placeOrder = new PlaceOrder(
                 ApplicationDomain.PartnerCenterClient.Customers.ById(CustomerId),
@@ -217,10 +236,25 @@ namespace Microsoft.Store.PartnerCenter.Storefront.BusinessLogic.Commerce
                 ApplicationDomain.CustomerPurchasesRepository,
                 new CustomerPurchaseEntity(CommerceOperationType.Renewal, Guid.NewGuid().ToString(), CustomerId, subscriptionId, partnerCenterSubscription.Quantity, partnerOfferPrice, rightNow)));
 
-            // extend the expiry date by one year
+            DateTime expirationDate = subscriptionExpiryDate;
+            BrandingConfiguration portalBranding = await ApplicationDomain.Instance.PortalBranding.RetrieveAsync().ConfigureAwait(false);
+
+            switch (portalBranding.BillingCycle)
+            {
+                case BillingCycleType.Annual:
+                    expirationDate = expirationDate.AddYears(1);
+                    break;
+                case BillingCycleType.Monthly:
+                    expirationDate = expirationDate.AddMonths(1);
+                    break;
+                default:
+                    throw new NotImplementedException($"Billing cycle {portalBranding.BillingCycle} is not implemented");
+            }
+
+            // extend the expiry date by one month or one year
             subTransactions.Add(new UpdatePersistedSubscription(
                 ApplicationDomain.CustomerSubscriptionsRepository,
-                new CustomerSubscriptionEntity(CustomerId, subscriptionId, partnerOfferId, subscriptionExpiryDate.AddYears(1))));
+                new CustomerSubscriptionEntity(CustomerId, subscriptionId, partnerOfferId, expirationDate)));
 
             // add a capture payment to the transaction pipeline
             subTransactions.Add(new CapturePayment(PaymentGateway, () => paymentAuthorization.Result));
@@ -302,13 +336,14 @@ namespace Microsoft.Store.PartnerCenter.Storefront.BusinessLogic.Commerce
         /// Builds a Microsoft Partner Center order from a list of purchase line items.
         /// </summary>
         /// <param name="purchaseLineItems">The purchase line items.</param>
+        /// <param name="billingCycle">The order billing cycle.</param>
         /// <returns>The Partner Center Order.</returns>
-        private Order BuildPartnerCenterOrder(IEnumerable<PurchaseLineItemWithOffer> purchaseLineItems)
+        private Order BuildPartnerCenterOrder(IEnumerable<PurchaseLineItemWithOffer> purchaseLineItems, BillingCycleType billingCycle)
         {
             int lineItemNumber = 0;
             ICollection<OrderLineItem> partnerCenterOrderLineItems = new List<OrderLineItem>();
 
-            // build the Partner Center order line items
+            // Build the Partner Center order line items
             foreach (PurchaseLineItemWithOffer lineItem in purchaseLineItems)
             {
                 // add the line items to the partner center order and calculate the price to charge
@@ -320,10 +355,26 @@ namespace Microsoft.Store.PartnerCenter.Storefront.BusinessLogic.Commerce
                 });
             }
 
-            // bundle the order line items into a partner center order
+            // Get the store billing cycle and update the order
+            PartnerCenter.Models.Offers.BillingCycleType orderBillingCycle;
+
+            switch (billingCycle)
+            {
+                case BillingCycleType.Annual:
+                    orderBillingCycle = PartnerCenter.Models.Offers.BillingCycleType.Annual;
+                    break;
+                case BillingCycleType.Monthly:
+                    orderBillingCycle = PartnerCenter.Models.Offers.BillingCycleType.Monthly;
+                    break;
+                default:
+                    throw new NotImplementedException($"Billing cycle {billingCycle} is not implemented");
+            }
+
+            // Bundle the order line items into a partner center order
             return new Order()
             {
                 ReferenceCustomerId = CustomerId,
+                BillingCycle = orderBillingCycle,
                 LineItems = partnerCenterOrderLineItems
             };
         }

--- a/src/Storefront/BusinessLogic/Commerce/OrderNormalizer.cs
+++ b/src/Storefront/BusinessLogic/Commerce/OrderNormalizer.cs
@@ -222,8 +222,13 @@ namespace Microsoft.Store.PartnerCenter.Storefront.BusinessLogic.Commerce
                 throw new PartnerDomainException(ErrorCode.SubscriptionExpired);
             }
 
-            decimal proratedSeatCharge = Math.Round(CommerceOperations.CalculateProratedSeatCharge(subscriptionToAugment.ExpiryDate, partnerOffer.Price), Resources.Culture.NumberFormat.CurrencyDecimalDigits);
-            decimal totalCharge = Math.Round(proratedSeatCharge * seatsToPurchase, Resources.Culture.NumberFormat.CurrencyDecimalDigits);
+            BrandingConfiguration portalBranding = await ApplicationDomain.Instance.PortalBranding.RetrieveAsync().ConfigureAwait(false);
+
+            decimal proratedSeatCharge = Math.Round(CommerceOperations.CalculateProratedSeatCharge(subscriptionToAugment.ExpiryDate,
+                                                                                                   partnerOffer.Price, 
+                                                                                                   portalBranding.BillingCycle), 
+                                                    Resources.Culture.NumberFormat.CurrencyDecimalDigits);
+            //decimal totalCharge = Math.Round(proratedSeatCharge * seatsToPurchase, Resources.Culture.NumberFormat.CurrencyDecimalDigits);
 
             List<OrderSubscriptionItemViewModel> resultOrderSubscriptions = new List<OrderSubscriptionItemViewModel>
             {

--- a/src/Storefront/BusinessLogic/Offers/PartnerOffersRepository.cs
+++ b/src/Storefront/BusinessLogic/Offers/PartnerOffersRepository.cs
@@ -71,10 +71,28 @@ namespace Microsoft.Store.PartnerCenter.Storefront.BusinessLogic.Offers
                 // Offers.ByCountry is required to pull country / region specific offers. 
                 PartnerCenter.Models.ResourceCollection<PartnerCenter.Models.Offers.Offer> partnerCenterOffers = await localeSpecificPartnerCenterClient.Offers.ByCountry(ApplicationDomain.PortalLocalization.CountryIso2Code).GetAsync().ConfigureAwait(false);
 
+                // Get the current billing cycle to filter down the eligible offers
+                BrandingConfiguration portalBranding = await ApplicationDomain.Instance.PortalBranding.RetrieveAsync().ConfigureAwait(false);
+                PartnerCenter.Models.Offers.BillingCycleType offerBillingCycle = PartnerCenter.Models.Offers.BillingCycleType.Unknown;
+
+                switch (portalBranding.BillingCycle)
+                {
+                    case BillingCycleType.Annual:
+                        offerBillingCycle = PartnerCenter.Models.Offers.BillingCycleType.Monthly;
+                        break;
+                    case BillingCycleType.Monthly:
+                        offerBillingCycle = PartnerCenter.Models.Offers.BillingCycleType.Annual;
+                        break;
+                    default:
+                        throw new NotImplementedException($"Billing cycle {portalBranding.BillingCycle} is not implemented");
+                }
+
+                // Get offers which support the desired billing cycle
                 IEnumerable<PartnerCenter.Models.Offers.Offer> eligibleOffers = partnerCenterOffers?.Items.Where(offer =>
                     !offer.IsAddOn &&
                     (offer.PrerequisiteOffers == null || !offer.PrerequisiteOffers.Any())
-                    && offer.IsAvailableForPurchase);
+                    && offer.IsAvailableForPurchase
+                    && offer.SupportedBillingCycles.Contains(offerBillingCycle));
 
                 microsoftOffers = new List<MicrosoftOffer>();
 

--- a/src/Storefront/Controllers/AdminConsoleController.cs
+++ b/src/Storefront/Controllers/AdminConsoleController.cs
@@ -148,6 +148,12 @@ namespace Microsoft.Store.PartnerCenter.Storefront.Controllers
                 brandingConfiguration.InstrumentationKey = HttpContext.Current.Request.Form["InstrumentationKey"];
             }
 
+            if (!string.IsNullOrWhiteSpace(HttpContext.Current.Request.Form["BillingCycle"])
+                && Enum.TryParse(HttpContext.Current.Request.Form["BillingCycle"], out BillingCycleType billingCycle))
+            {
+                brandingConfiguration.BillingCycle = billingCycle;
+            }
+
             BrandingConfiguration updatedBrandingConfiguration = await ApplicationDomain.Instance.PortalBranding.UpdateAsync(brandingConfiguration).ConfigureAwait(false);
             bool isPaymentConfigurationSetup = await ApplicationDomain.Instance.PaymentConfigurationRepository.IsConfiguredAsync().ConfigureAwait(false);
 
@@ -170,7 +176,7 @@ namespace Microsoft.Store.PartnerCenter.Storefront.Controllers
         [HttpGet]
         public async Task<IEnumerable<PartnerOffer>> GetOffers()
         {
-            return (await ApplicationDomain.Instance.OffersRepository.RetrieveAsync().ConfigureAwait(false)).Where(offer => !offer.IsInactive);
+            return (await ApplicationDomain.Instance.OffersRepository.RetrieveAsync().ConfigureAwait(false)).OrderBy(o => o.DisplayIndex).Where(offer => !offer.IsInactive);
         }
 
         /// <summary>

--- a/src/Storefront/Controllers/CustomerAccountController.cs
+++ b/src/Storefront/Controllers/CustomerAccountController.cs
@@ -152,8 +152,13 @@ namespace Microsoft.Store.PartnerCenter.Storefront.Controllers
                     isEditable = false;
                 }
 
-                // Compute the pro rated price per seat for this subcription & return for client side processing during updates. 
-                decimal proratedPerSeatPrice = Math.Round(CommerceOperations.CalculateProratedSeatCharge(subscription.ExpiryDate, portalOfferPrice), responseCulture.NumberFormat.CurrencyDecimalDigits);
+                BrandingConfiguration portalBranding = await ApplicationDomain.Instance.PortalBranding.RetrieveAsync().ConfigureAwait(false);
+
+                // Compute the pro rated price per seat for this subcription & return for client side processing during updates.
+                decimal proratedPerSeatPrice = Math.Round(CommerceOperations.CalculateProratedSeatCharge(subscription.ExpiryDate,
+                                                                                                         portalOfferPrice,
+                                                                                                         portalBranding.BillingCycle),
+                                                          Resources.Culture.NumberFormat.CurrencyDecimalDigits);
 
                 SubscriptionViewModel subscriptionItem = new SubscriptionViewModel()
                 {

--- a/src/Storefront/Controllers/OrderController.cs
+++ b/src/Storefront/Controllers/OrderController.cs
@@ -399,8 +399,13 @@ namespace Microsoft.Store.PartnerCenter.Storefront.Controllers
                     isEditable = false;
                 }
 
+                BrandingConfiguration portalBranding = await ApplicationDomain.Instance.PortalBranding.RetrieveAsync().ConfigureAwait(false);
+
                 // Compute the pro rated price per seat for this subcription & return for client side processing during updates. 
-                decimal proratedPerSeatPrice = Math.Round(CommerceOperations.CalculateProratedSeatCharge(subscription.ExpiryDate, portalOfferPrice), responseCulture.NumberFormat.CurrencyDecimalDigits);
+                decimal proratedPerSeatPrice = Math.Round(CommerceOperations.CalculateProratedSeatCharge(subscription.ExpiryDate,
+                                                                                                         portalOfferPrice,
+                                                                                                         portalBranding.BillingCycle),
+                                                          Resources.Culture.NumberFormat.CurrencyDecimalDigits);
 
                 SubscriptionViewModel subscriptionItem = new SubscriptionViewModel()
                 {

--- a/src/Storefront/Controllers/PartnerOfferController.cs
+++ b/src/Storefront/Controllers/PartnerOfferController.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Store.PartnerCenter.Storefront.Controllers
                     }
                 }
 
-                offerCatalogViewModel.Offers = partnerOffers.Where(offer => !offer.IsInactive);
+                offerCatalogViewModel.Offers = partnerOffers.OrderBy(o => o.DisplayIndex).Where(offer => !offer.IsInactive);
             }
 
             return offerCatalogViewModel;

--- a/src/Storefront/Controllers/TemplateController.cs
+++ b/src/Storefront/Controllers/TemplateController.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Store.PartnerCenter.Storefront.Controllers
 
             ViewBag.OrganizationName = portalBranding.OrganizationName;
             ViewBag.IsPortalAdmin = principal.IsPortalAdmin;
+            ViewBag.BillingCycle = portalBranding.BillingCycle;
 
             return PartialView();
         }
@@ -264,6 +265,7 @@ namespace Microsoft.Store.PartnerCenter.Storefront.Controllers
             ViewBag.ContactSales = portalBranding.ContactSales;
 
             ViewBag.CurrencySymbol = ApplicationDomain.Instance.PortalLocalization.CurrencySymbol;
+            ViewBag.BillingCycle = portalBranding.BillingCycle;
 
             return PartialView();
         }

--- a/src/Storefront/Models/BillingCycleType.cs
+++ b/src/Storefront/Models/BillingCycleType.cs
@@ -1,0 +1,14 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="BrandingConfiguration.cs" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.Store.PartnerCenter.Storefront.Models
+{
+    public enum BillingCycleType
+    {
+        Annual = 0,
+        Monthly = 1
+    }
+}

--- a/src/Storefront/Models/BrandingConfiguration.cs
+++ b/src/Storefront/Models/BrandingConfiguration.cs
@@ -63,5 +63,10 @@ namespace Microsoft.Store.PartnerCenter.Storefront.Models
         /// Gets or sets a privacy link for using the portal.
         /// </summary>
         public Uri PrivacyAgreement { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configured billing cycle for the portal.
+        /// </summary>
+        public BillingCycleType BillingCycle { get; set; }
     }
 }

--- a/src/Storefront/Models/PartnerOffer.cs
+++ b/src/Storefront/Models/PartnerOffer.cs
@@ -58,5 +58,10 @@ namespace Microsoft.Store.PartnerCenter.Storefront.Models
         /// Gets or sets the offer's thumbnail image.
         /// </summary>
         public Uri Thumbnail { get; set; }
+
+        /// <summary>
+        /// Gets or sets the offer's display index.
+        /// </summary>
+        public int DisplayIndex { get; set; }
     }
 }

--- a/src/Storefront/Resources.Designer.cs
+++ b/src/Storefront/Resources.Designer.cs
@@ -295,6 +295,24 @@ namespace Microsoft.Store.PartnerCenter.Storefront {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Billing cycle:.
+        /// </summary>
+        public static string BillingCycleFieldHeader {
+            get {
+                return ResourceManager.GetString("BillingCycleFieldHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You can choose between Monthly or Annual billing for offers. Note that changing the billing cycle will not update pricing for any existing offers..
+        /// </summary>
+        public static string BillingCycleFieldSubText {
+            get {
+                return ResourceManager.GetString("BillingCycleFieldSubText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to based billing.
         /// </summary>
         public static string BillingTypeListRowCaption {
@@ -3346,6 +3364,15 @@ namespace Microsoft.Store.PartnerCenter.Storefront {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Display index:.
+        /// </summary>
+        public static string DisplayIndexHeader {
+            get {
+                return ResourceManager.GetString("DisplayIndexHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The domain is not available. Please enter another domain prefix.
         /// </summary>
         public static string DomainNotAvailable {
@@ -3945,6 +3972,24 @@ namespace Microsoft.Store.PartnerCenter.Storefront {
         public static string MicrosoftOfferRetrievalErrorMessage {
             get {
                 return ResourceManager.GetString("MicrosoftOfferRetrievalErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Monthly price.
+        /// </summary>
+        public static string MonthlyPriceCaption {
+            get {
+                return ResourceManager.GetString("MonthlyPriceCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Monthly total.
+        /// </summary>
+        public static string MonthlyTotalCaption {
+            get {
+                return ResourceManager.GetString("MonthlyTotalCaption", resourceCulture);
             }
         }
         
@@ -5137,6 +5182,24 @@ namespace Microsoft.Store.PartnerCenter.Storefront {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to expires on.
+        /// </summary>
+        public static string SubscriptionSummaryMonthlyCommitmentExpiryCaption {
+            get {
+                return ResourceManager.GetString("SubscriptionSummaryMonthlyCommitmentExpiryCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Price Paid.
+        /// </summary>
+        public static string SubscriptionSummaryMonthlyPricePrefixCaption {
+            get {
+                return ResourceManager.GetString("SubscriptionSummaryMonthlyPricePrefixCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Price paid is displayed pro-rated as applicable. .
         /// </summary>
         public static string SubscriptionSummaryProratepriceCaption {
@@ -5362,6 +5425,15 @@ namespace Microsoft.Store.PartnerCenter.Storefront {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to user/month.
+        /// </summary>
+        public static string UserPerMonth {
+            get {
+                return ResourceManager.GetString("UserPerMonth", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to user/year.
         /// </summary>
         public static string UserPerYear {
@@ -5412,6 +5484,24 @@ namespace Microsoft.Store.PartnerCenter.Storefront {
         public static string YourAnnualPriceCaption {
             get {
                 return ResourceManager.GetString("YourAnnualPriceCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Display index:.
+        /// </summary>
+        public static string YourDisplayIndexCaption {
+            get {
+                return ResourceManager.GetString("YourDisplayIndexCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Monthly price:.
+        /// </summary>
+        public static string YourMonthlyPriceCaption {
+            get {
+                return ResourceManager.GetString("YourMonthlyPriceCaption", resourceCulture);
             }
         }
         

--- a/src/Storefront/Resources.resx
+++ b/src/Storefront/Resources.resx
@@ -1908,4 +1908,34 @@
   <data name="CountryNameZW" xml:space="preserve">
     <value>Zimbabwe</value>
   </data>
+  <data name="UserPerMonth" xml:space="preserve">
+    <value>user/month</value>
+  </data>
+  <data name="BillingCycleFieldHeader" xml:space="preserve">
+    <value>Billing cycle:</value>
+  </data>
+  <data name="BillingCycleFieldSubText" xml:space="preserve">
+    <value>You can choose between Monthly or Annual billing for offers. Note that changing the billing cycle will not update pricing for any existing offers.</value>
+  </data>
+  <data name="DisplayIndexHeader" xml:space="preserve">
+    <value>Display index:</value>
+  </data>
+  <data name="MonthlyPriceCaption" xml:space="preserve">
+    <value>Monthly price</value>
+  </data>
+  <data name="MonthlyTotalCaption" xml:space="preserve">
+    <value>Monthly total</value>
+  </data>
+  <data name="SubscriptionSummaryMonthlyCommitmentExpiryCaption" xml:space="preserve">
+    <value>expires on</value>
+  </data>
+  <data name="SubscriptionSummaryMonthlyPricePrefixCaption" xml:space="preserve">
+    <value>Price Paid</value>
+  </data>
+  <data name="YourDisplayIndexCaption" xml:space="preserve">
+    <value>Display index:</value>
+  </data>
+  <data name="YourMonthlyPriceCaption" xml:space="preserve">
+    <value>Monthly price:</value>
+  </data>
 </root>

--- a/src/Storefront/Scripts/Plugins/AddOrUpdateOfferPresenter.js
+++ b/src/Storefront/Scripts/Plugins/AddOrUpdateOfferPresenter.js
@@ -18,6 +18,7 @@
         MicrosoftOffer: ko.observable(this.isNewOffer ? "" : existingOffer.MicrosoftOffer),
         Title: ko.observable(this.isNewOffer ? "" : existingOffer.Title),
         SubTitle: ko.observable(this.isNewOffer ? "" : existingOffer.SubTitle),
+        DisplayIndex: ko.observable(this.isNewOffer ? "" : existingOffer.DisplayIndex),
         Price: ko.observable(this.isNewOffer ? "" : Globalize.format(existingOffer.Price, "n")),
         Features: ko.observableArray([]),
         Summary: ko.observableArray([]),
@@ -203,7 +204,8 @@ Microsoft.WebPortal.AddOrUpdateOfferPresenter.prototype.onSaveOffer = function (
         MicrosoftOfferId: this.viewModel.MicrosoftOffer().Offer.Id,
         Title: this.viewModel.Title(),
         Subtitle: this.viewModel.SubTitle(),
-        Price: 0.0
+        Price: 0.0,
+        DisplayIndex: this.viewModel.DisplayIndex()
     };
 
     // Only save the culture neutral value for price in the backend. 
@@ -283,6 +285,7 @@ Microsoft.WebPortal.AddOrUpdateOfferPresenter.prototype.onSelectBaseOffer = func
 
         self.viewModel.MicrosoftOffer(self.OfferSelectionWizardViewModel.offerList.getSelectedRows()[0].OriginalOffer);
         self.viewModel.Title(self.viewModel.MicrosoftOffer().Offer.Name);
+        self.viewModel.DisplayIndex(0);
         self.webPortal.Services.Dialog.hide();
         self.saveOfferAction.enabled(true);
     });

--- a/src/Storefront/Scripts/Plugins/BrandingSetupPresenter.js
+++ b/src/Storefront/Scripts/Plugins/BrandingSetupPresenter.js
@@ -25,7 +25,9 @@
         InstrumentationKey: ko.observable(""),
         OrganizationLogo: ko.observable(""),
         OrganizationName: ko.observable(""),
-        PrivacyAgreement: ko.observable("")
+        PrivacyAgreement: ko.observable(""),
+        BillingCycle: ko.observable(),
+        AvailableBillingCycleTypes: ko.observableArray([{ name: 'Annual', id: 0 }, { name: 'Monthly', id: 1 }])
     };
 };
 
@@ -152,6 +154,8 @@ Microsoft.WebPortal.BrandingSetupPresenter.prototype.onSaveBranding = function (
     formData.append("HeaderImage", this.viewModel.HeaderImage());
     formData.append("InstrumentationKey", this.viewModel.InstrumentationKey());
     formData.append("PrivacyAgreement", this.viewModel.PrivacyAgreement());
+
+    formData.append("BillingCycle", this.viewModel.BillingCycle());
 
     var saveBrandingServerCall = this.webPortal.ServerCallManager.create(this.feature,
         function () {
@@ -320,6 +324,7 @@ Microsoft.WebPortal.BrandingSetupPresenter.prototype._updateViewModel = function
     this.viewModel.HeaderImage(this.existingBrandingConfiguration.HeaderImage);
     this.viewModel.InstrumentationKey(this.existingBrandingConfiguration.InstrumentationKey);
     this.viewModel.PrivacyAgreement(this.existingBrandingConfiguration.PrivacyAgreement);
+    this.viewModel.BillingCycle(this.existingBrandingConfiguration.BillingCycle.toString());
 };
 
 
@@ -354,7 +359,8 @@ Microsoft.WebPortal.BrandingSetupPresenter.prototype._setupActions = function ()
             this.viewModel.OrganizationLogo() !== this.existingBrandingConfiguration.OrganizationLogo |
             this.viewModel.HeaderImage() !== this.existingBrandingConfiguration.HeaderImage |
             this.viewModel.InstrumentationKey() !== this.existingBrandingConfiguration.InstrumentationKey |
-            this.viewModel.PrivacyAgreement() !== this.existingBrandingConfiguration.PrivacyAgreement;
+            this.viewModel.PrivacyAgreement() !== this.existingBrandingConfiguration.PrivacyAgreement |
+            this.viewModel.BillingCycle() !== this.existingBrandingConfiguration.BillingCycle;
 
         isFormUpdated = isFormUpdated | this.viewModel.ContactUs.Email() !== this.existingBrandingConfiguration.ContactUs.Email |
             this.viewModel.ContactUs.Phone() !== this.existingBrandingConfiguration.ContactUs.Phone;

--- a/src/Storefront/Scripts/Plugins/OfferListPresenter.js
+++ b/src/Storefront/Scripts/Plugins/OfferListPresenter.js
@@ -123,7 +123,8 @@ Microsoft.WebPortal.OfferListPresenter.prototype.onCellClicked = function (colum
         Features: row.PartnerOffer.Features,
         Summary: row.PartnerOffer.Summary,
         Logo: row.PartnerOffer.LogoUri,
-        Thumbnail: row.PartnerOffer.ThumbnailUri
+        Thumbnail: row.PartnerOffer.ThumbnailUri,
+        DisplayIndex: row.PartnerOffer.DisplayIndex
     };
 
     // go to the update offer feature and pass it the clicked offer
@@ -255,6 +256,7 @@ Microsoft.WebPortal.OfferListPresenter.prototype._retrievePartnerOffers = functi
                 var offerToPush = {
                     PartnerOffer: partnerOffers[i],
                     FormattedPrice: Globalize.format(partnerOffers[i].Price, "c"),
+                    DisplayIndex: partnerOffers[i].DisplayIndex,
                     MicrosoftOffer: function () {
                         for (var j in microsoftOffers) {
                             if (partnerOffers[i].MicrosoftOfferId === microsoftOffers[j].Offer.Id) {

--- a/src/Storefront/Storefront.csproj
+++ b/src/Storefront/Storefront.csproj
@@ -313,6 +313,7 @@
     <Compile Include="Filters\WebApi\PortalAuthorizeAttribute.cs" />
     <Compile Include="Filters\WebApi\ErrorHandlerAttribute.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Models\BillingCycleType.cs" />
     <Compile Include="Models\CommerceOperationType.cs" />
     <Compile Include="BusinessLogic\Commerce\CustomerPurchasesRepository.cs" />
     <Compile Include="Models\CustomerLicensesModel.cs" />

--- a/src/Storefront/Views/Controls/AddSubscriptions.cshtml
+++ b/src/Storefront/Views/Controls/AddSubscriptions.cshtml
@@ -34,7 +34,7 @@
                 <label class="monthly-fee">@Resources.SubscriptionSummaryRateCaption </label>
             </td>
             <td class="right-aligned" width="10%">
-                <label class="monthly-fee">@Resources.AnnualTotalCaption</label>                                
+                <label class="monthly-fee">@(ViewBag.BillingCycle == Microsoft.Store.PartnerCenter.Storefront.Models.BillingCycleType.Annual ? Resources.AnnualTotalCaption : Resources.MonthlyTotalCaption)</label>                                
             </td>
         </tr>
         <tr style="vertical-align: top">

--- a/src/Storefront/Views/Controls/OfferTile.cshtml
+++ b/src/Storefront/Views/Controls/OfferTile.cshtml
@@ -11,9 +11,9 @@
             </td>
         </tr>
         <tr>
-            <td class="PriceContainer">                
+            <td class="PriceContainer">
                 <label data-bind="text: viewModel.formattedPrice, css: { Hoverable: viewModel.isSelectable() }"></label>
-                <label class="PerYear">@Resources.UserPerYear</label>
+                <label class="PerYear">@(ViewBag.BillingCycle == Microsoft.Store.PartnerCenter.Storefront.Models.BillingCycleType.Annual ? Resources.UserPerYear : Resources.UserPerMonth)</label>
                 <label title="Buy this offer" class="Link BuyNow" data-bind="visible: viewModel.showBuyLink, click: onBuyNowClicked">@Resources.BuyNow</label>
             </td>
         </tr>

--- a/src/Storefront/Views/Shared/AddOrUpdateOffer.cshtml
+++ b/src/Storefront/Views/Shared/AddOrUpdateOffer.cshtml
@@ -54,12 +54,22 @@
             </tr>
             <tr class="InlineBlock FullWidth">
                 <td class="CustomizationHeader">
-                    @Resources.YourAnnualPriceCaption <label class="Required"><label>*</label></label>
+                    @(ViewBag.BillingCycle == Microsoft.Store.PartnerCenter.Storefront.Models.BillingCycleType.Annual ? Resources.YourAnnualPriceCaption : Resources.YourMonthlyPriceCaption) <label class="Required"><label>*</label></label>
                 </td>
                 <td>
                     <input id="OfferPrice" name="OfferPrice" class="Price" type="text" data-bind="textInput : viewModel.Price"> <label class="MetroMediumLight">@ViewBag.CurrencySymbol</label>
                 </td>
             </tr>
+
+            <tr class="InlineBlock FullWidth">
+                <td class="CustomizationHeader">
+                    @Resources.YourDisplayIndexCaption <label class="Required"><label>*</label></label>
+                </td>
+                <td>
+                    <input id="OfferDisplayIndex" name="OfferDisplayIndex" class="Price" type="text" data-bind="textInput : viewModel.DisplayIndex">
+                </td>
+            </tr>
+
             <tr class="DetailedFeaturesContainer">
                 <td class="DetailedFeatures">
                     @Resources.FeaturesCaption
@@ -113,7 +123,7 @@
                         <form >
                                 <fieldset class="SearchFieldSet" style="background-color:white;padding-top: 0px;padding-bottom: 0px;border: 0px;" >
                                 <input class="InputSearchField" placeholder="@Resources.SelectSearchByOffersPlaceholder" data-bind="value: searchTerm, valueUpdate: 'afterkeydown' " />
-                                <button class="InputSearchButton" data-bind="click: searchButtonClicked" style="padding-top: 8px;height:30px;padding-bottom: 8px;margin-top: 0px;margin-bottom: 0px;"><img src="/Content/Images/WebPortal/search.png" @*width="25" height="25"*@></button>
+                                <button class="InputSearchButton" data-bind="click: searchButtonClicked" style="padding-top: 8px;height:30px;padding-bottom: 8px;margin-top: 0px;margin-bottom: 0px;"><img src="/Content/Images/WebPortal/search.png"></button>
                                 </fieldset>
                                 </form>  
                         
@@ -154,6 +164,9 @@
                 OfferPrice: {
                     required: true,
                     validateprice:true
+                },
+                OfferDisplayIndex: {
+                    required: true
                 }
             },
             messages: {

--- a/src/Storefront/Views/Shared/BrandingSetup.cshtml
+++ b/src/Storefront/Views/Shared/BrandingSetup.cshtml
@@ -106,7 +106,7 @@
                     @Resources.AgreementUserIdFieldHeader
                 </td>
                 <td class="Subtext">
-                    <input id="InstrumentationKey" name="AgreementUserId" type="text" class="InputField FullWidthInput" data-bind="textinput: viewModel.AgreementUserId" /><br />
+                    <input id="AgreementUserId" name="AgreementUserId" type="text" class="InputField FullWidthInput" data-bind="textinput: viewModel.AgreementUserId" /><br />
                     @Resources.AgreementUserIdSubText
                 </td>
             </tr>
@@ -117,6 +117,15 @@
                 <td class="Subtext">
                     <input id="InstrumentationKey" name="InstrumentationKey" type="text" class="InputField FullWidthInput" data-bind="textinput: viewModel.InstrumentationKey" /><br />
                     @Resources.InstrumentationKeyFieldSubText
+                </td>
+            </tr>
+            <tr>
+                <td class="TitleCell">
+                    @Resources.BillingCycleFieldHeader
+                </td>
+                <td class="Subtext">
+                    <select id="BillingCycle" name="BillingCycle" class="InputField" data-bind="options: viewModel.AvailableBillingCycleTypes, optionsValue: 'id', optionsText: 'name', value: viewModel.BillingCycle"></select><br />
+                    @Resources.BillingCycleFieldSubText
                 </td>
             </tr>
             <tr>

--- a/src/Storefront/Views/Shared/OfferList.cshtml
+++ b/src/Storefront/Views/Shared/OfferList.cshtml
@@ -25,12 +25,13 @@
     <div class="PartnerOfferDetails">
         <label class="Title" data-bind="text: row.PartnerOffer.Title"></label><br />
         @Resources.PriceHeader <label class="SubTitle" data-bind="text: row.FormattedPrice"></label><br />
+        @Resources.DisplayIndexHeader <label class="SubTitle" data-bind="text: row.DisplayIndex"></label><br />
 
         <table cellspacing="0">
             <tr>
                 <!-- ko if: row.PartnerOffer.Summary && row.PartnerOffer.Summary.length > 0 -->
                 <td>
-                    
+
                     @Resources.SummaryListRowCaption
                     <ul>
                         <!-- ko foreach: row.PartnerOffer.Summary -->

--- a/src/Storefront/Views/Shared/ProcessOrder.cshtml
+++ b/src/Storefront/Views/Shared/ProcessOrder.cshtml
@@ -87,7 +87,7 @@
                         @Resources.SubscriptionSummaryRateCaption
                     </td>
                     <td class="right-aligned">
-                        @Resources.AnnualPriceCaption
+                        @(ViewBag.BillingCycle == Microsoft.Store.PartnerCenter.Storefront.Models.BillingCycleType.Annual ? Resources.AnnualPriceCaption : Resources.MonthlyPriceCaption)
                     </td>
                     <td />
                 </tr>
@@ -95,7 +95,7 @@
                 <tr>
                     <td>
                         <label class="medium-text" data-bind="text: $data.FriendlyName"></label>
-                        <label> - @Resources.SubscriptionSummaryAnnualCommitmentExpiryCaption </label><label data-bind="text: $data.SubscriptionExpiryDate"></label>
+                        <label> - @(ViewBag.BillingCycle == Microsoft.Store.PartnerCenter.Storefront.Models.BillingCycleType.Annual ? Resources.SubscriptionSummaryAnnualCommitmentExpiryCaption : Resources.SubscriptionSummaryMonthlyCommitmentExpiryCaption) </label><label data-bind="text: $data.SubscriptionExpiryDate"></label>
                     </td>
                     <td class="right-aligned">
                         <label data-bind="text: $data.LicensesTotal"></label>

--- a/src/Storefront/Views/Shared/Subscriptions.cshtml
+++ b/src/Storefront/Views/Shared/Subscriptions.cshtml
@@ -31,7 +31,7 @@
                         @Resources.SubscriptionSummaryRateCaption
                     </td>
                     <td class="right-aligned">
-                        *@Resources.SubscriptionSummaryAnnualPricePrefixCaption
+                        *@(ViewBag.BillingCycle == Microsoft.Store.PartnerCenter.Storefront.Models.BillingCycleType.Annual ? Resources.SubscriptionSummaryAnnualPricePrefixCaption : Resources.SubscriptionSummaryMonthlyPricePrefixCaption)
                     </td>
                     <td />
                     <td />
@@ -41,7 +41,7 @@
                 <tr class="SubscriptionRow">
                     <td>
                         <label class="abovemedium-text" data-bind="text: $data.FriendlyName"></label>
-                        <label> - @Resources.SubscriptionSummaryAnnualCommitmentExpiryCaption </label><label data-bind="text: $data.SubscriptionExpiryDate"></label>
+                        <label> - @(ViewBag.BillingCycle == Microsoft.Store.PartnerCenter.Storefront.Models.BillingCycleType.Annual ? Resources.SubscriptionSummaryAnnualCommitmentExpiryCaption : Resources.SubscriptionSummaryMonthlyCommitmentExpiryCaption) </label><label data-bind="text: $data.SubscriptionExpiryDate"></label>
                     </td>
                     <td class="left-aligned">
                         <label data-bind="text: $data.LicensesTotal"></label>

--- a/src/Storefront/Views/Shared/UpdateSubscriptions.cshtml
+++ b/src/Storefront/Views/Shared/UpdateSubscriptions.cshtml
@@ -26,7 +26,7 @@
                         <label class="monthly-fee">@Resources.SubscriptionSummaryRateCaption</label>
                     </td>
                     <td class="right-aligned">
-                        <label class="monthly-fee">@Resources.AnnualTotalCaption</label>
+                        <label class="monthly-fee">@(ViewBag.BillingCycle == Microsoft.Store.PartnerCenter.Storefront.Models.BillingCycleType.Annual ? Resources.AnnualTotalCaption : Resources.MonthlyTotalCaption)</label>
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
# Adding support for monthly billing (issue #69). 

The store config / branding page now has a Billing Cycle option which lets an administrator choose between monthly or annual pricing.

# Adding display index for offers for partner offers

To allow more customisation of the customer facing storefront, partner offers can now be assigned a display index which is then used to sort partner offers in the desired order.

## Issues / comments
 - The billing cycle field is stored in the BrandingConfiguration class - not sure if this is the best place for it
 - A number of new resource strings were added to support the new behaviour, only the English resource file has been updated